### PR TITLE
feat(seo): add site-wide Open Graph preview image

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -26,6 +26,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   const t = await getTranslations({ locale, namespace: "Metadata" })
 
   return {
+    metadataBase: new URL("https://turboot.com"),
     title: t("title"),
     description: t("description"),
     keywords: t("keywords"),

--- a/src/app/[locale]/opengraph-image.tsx
+++ b/src/app/[locale]/opengraph-image.tsx
@@ -1,0 +1,49 @@
+import { ImageResponse } from "next/og"
+
+// Site-wide social preview image (WhatsApp, LinkedIn, X, ...). Next injects the
+// og:image and twitter:image meta tags for every page under [locale] from this file.
+export const alt = "Turboot"
+export const size = { width: 1200, height: 630 }
+export const contentType = "image/png"
+
+export default function OpengraphImage() {
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "center",
+        padding: "90px",
+        background: "linear-gradient(135deg, #6d28d9 0%, #4f46e5 55%, #2563eb 100%)",
+        color: "white",
+        fontFamily: "sans-serif",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "26px",
+        }}
+      >
+        <div
+          style={{
+            width: 0,
+            height: 0,
+            borderLeft: "34px solid transparent",
+            borderRight: "34px solid transparent",
+            borderBottom: "58px solid white",
+          }}
+        />
+        <div style={{ fontSize: 104, fontWeight: 800, letterSpacing: "-0.04em" }}>Turboot</div>
+      </div>
+      <div style={{ fontSize: 44, marginTop: 30, opacity: 0.92, maxWidth: 900 }}>
+        Webontwikkeling, hosting en beheerd Microsoft 365
+      </div>
+      <div style={{ fontSize: 30, marginTop: 46, opacity: 0.72 }}>turboot.com</div>
+    </div>,
+    { ...size }
+  )
+}


### PR DESCRIPTION
## What

Social shares (WhatsApp, LinkedIn, X, ...) had **no `og:image`**, so platforms fell back to the tiny favicon as the thumbnail. This adds a proper branded social-preview image site-wide.

## How

- **Generated 1200x630 image** via `next/og` `ImageResponse` at `src/app/[locale]/opengraph-image.tsx`. Next injects `og:image` **and** `twitter:image` into every page under `[locale]` (home, m365, about, ...).
- Added **`metadataBase`** so the image URLs resolve absolutely.
- **Per-page titles/descriptions unchanged** (I did not set `og:title`/`og:description` in the layout, so each page's own `<title>`/`<meta description>` still drives the text in previews).

Design: violet-to-blue brand gradient, Turboot wordmark + tagline, `turboot.com`.

## Verify

- `npm run build` succeeds; route `/[locale]/opengraph-image` is generated.
- After deploy: re-share any turboot.com link (WhatsApp caches, so use a fresh URL or the [WhatsApp/Facebook debugger](https://developers.facebook.com/tools/debug/)) to see the banner.